### PR TITLE
Transform classes of all components of all variants.

### DIFF
--- a/gradle-plugin/src/main/java/dev/rikka/tools/refine/RefinePlugin.java
+++ b/gradle-plugin/src/main/java/dev/rikka/tools/refine/RefinePlugin.java
@@ -3,14 +3,13 @@ package dev.rikka.tools.refine;
 import com.android.build.api.instrumentation.InstrumentationScope;
 import com.android.build.api.variant.AndroidComponentsExtension;
 import com.android.build.api.variant.Component;
-import com.android.build.api.variant.HasAndroidTest;
+
 import kotlin.Unit;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * Gradle plugin that do the class rename works.
@@ -25,21 +24,13 @@ public class RefinePlugin implements Plugin<Project> {
 
         final AndroidComponentsExtension<?, ?, ?> components = target.getExtensions().getByType(AndroidComponentsExtension.class);
         components.onVariants(components.selector().all(), variant -> {
-            configureComponent(variant);
-            configureComponent(variant.getUnitTest());
-            if (variant instanceof HasAndroidTest) {
-                configureComponent(((HasAndroidTest) variant).getAndroidTest());
+            for (Component component : variant.getComponents()) {
+                component.getInstrumentation().transformClassesWith(
+                        RefineFactory.class,
+                        InstrumentationScope.ALL,
+                        (parameters) -> Unit.INSTANCE
+                );
             }
         });
-    }
-
-    private void configureComponent(@Nullable final Component component) {
-        if (component != null) {
-            component.getInstrumentation().transformClassesWith(
-                    RefineFactory.class,
-                    InstrumentationScope.ALL,
-                    (parameters) -> Unit.INSTANCE
-            );
-        }
     }
 }


### PR DESCRIPTION
As seen in the documentation for `getComponents`, it allows us to enumerate all components:
> components contains the variant along with its unitTests, androidTests, and testFixtures (if enabled).

Thus, this change simplifies the code further, but more importantly, the plugin now also transforms classes found in `testFixtures` (if they are used).